### PR TITLE
Add basedir to default file resolver for ant basedir support.

### DIFF
--- a/maven-config-processor-plugin/src/main/java/com/google/code/configprocessor/ant/ConfigProcessorTask.java
+++ b/maven-config-processor-plugin/src/main/java/com/google/code/configprocessor/ant/ConfigProcessorTask.java
@@ -68,7 +68,10 @@ public class ConfigProcessorTask extends Task {
 			for (NamespaceContext nsContext : namespaceContexts) {
 				namespaceContextsMap.put(nsContext.getPrefix(), nsContext.getUrl());
 			}
-			ConfigProcessor processor = new ConfigProcessor(encoding, indentSize, lineWidth, namespaceContextsMap, getProject().getBaseDir(), outputDirectory, useOutputDirectory, log, new DefaultFileResolver(), parserFeatures, failOnMissingXpath);
+			DefaultFileResolver fileResolver = new DefaultFileResolver();
+			File projectBaseDir = getProject().getBaseDir();
+			fileResolver.setBasedir(projectBaseDir.getAbsolutePath());
+			ConfigProcessor processor = new ConfigProcessor(encoding, indentSize, lineWidth, namespaceContextsMap, projectBaseDir, outputDirectory, useOutputDirectory, log, fileResolver, parserFeatures, failOnMissingXpath);
 			processor.init();
 			
 			Properties additionalProperties = loadIfPossible(specificProperties, log);

--- a/maven-config-processor-plugin/src/main/java/com/google/code/configprocessor/io/DefaultFileResolver.java
+++ b/maven-config-processor-plugin/src/main/java/com/google/code/configprocessor/io/DefaultFileResolver.java
@@ -19,12 +19,23 @@ import java.io.*;
 
 public class DefaultFileResolver implements FileResolver {
 
+	private String basedir;
+
 	public File resolve(String name) throws IOException {
 		File file = new File(name);
 		if (!file.exists()) {
-			throw new FileNotFoundException("File [" + name + "] does not exist");
+			file = new File(basedir, name);
+			if (!file.exists()) {
+				throw new FileNotFoundException("File [" + name +
+						"] does not exist. " + "looked in: " + new File(name) +
+						"\n" + file);
+			}
 		}
 		return file;
+	}
+	
+	public void setBasedir(String basedir) {
+		this.basedir = basedir;
 	}
 
 }


### PR DESCRIPTION
Solve problem of files not being found if working directory is not correct, for example in a gradle build from a different project directory.